### PR TITLE
Add Rust for pyca/cryptography 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@ FROM alpine:latest as main
 
 RUN set -eux; \
     apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates; \
-    apk --update add --virtual gcc musl-dev cargo; \
     apk --update add --virtual \
       build-dependencies \
       build-base \
       python3-dev \
       libffi-dev \
-      openssl-dev; \
+      openssl-dev \
+      musl-dev \
+      cargo; \
     pip3 install --upgrade pip cffi; \
     pip3 install ansible boto pywinrm; \
     apk del build-dependencies; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN set -eux; \
       openssl-dev; \
     pip3 install --upgrade pip cffi; \
     pip3 install ansible boto pywinrm; \
-    pip3 install docker; \
     apk del build-dependencies; \
     rm -rf /var/cache/apk/*; \
     mkdir -p /etc/ansible; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:latest as main
 
 RUN set -eux; \
     apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates; \
+    apk --update add gcc musl-dev python3-dev libffi-dev openssl-dev cargo; \
     apk --update add --virtual \
       build-dependencies \
       build-base \
@@ -10,6 +11,7 @@ RUN set -eux; \
       openssl-dev; \
     pip3 install --upgrade pip cffi; \
     pip3 install ansible boto pywinrm; \
+    pip3 install docker; \
     apk del build-dependencies; \
     rm -rf /var/cache/apk/*; \
     mkdir -p /etc/ansible; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest as main
 
 RUN set -eux; \
     apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates; \
-    apk --update add gcc musl-dev python3-dev libffi-dev openssl-dev cargo; \
+    apk --update add --virtual gcc musl-dev cargo; \
     apk --update add --virtual \
       build-dependencies \
       build-base \


### PR DESCRIPTION
See this issue: https://github.com/pyca/cryptography/issues/5771
And the changelog: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07

Sorry for the "docker stuff" in the commit history, I branched from something else I was doing.