### PR TITLE
Ensure SSH key has newline

### DIFF
--- a/assets/lib/ssh_config.rb
+++ b/assets/lib/ssh_config.rb
@@ -8,6 +8,9 @@ class SSHConfig
   end
 
   def create_key_file!(key_path, key)
+    unless key.end_with?("\n")
+      key << "\n"
+    end
     File.write key_path, key
     FileUtils.chmod 0600, key_path
   end

--- a/spec/integration/git_spec.rb
+++ b/spec/integration/git_spec.rb
@@ -18,7 +18,7 @@ describe "integration:git" do
     stdin = {
         "source" => {
             "ssh_private_key" => "ssh_key",
-            "git_private_key" => "git_key"
+            "git_private_key" => "git_key\n"
         },
         "params" => {
             "path" => "spec/fixtures",
@@ -32,7 +32,7 @@ describe "integration:git" do
     expect(File).to exist(git_private_key_file)
 
     git_private_key_contents = File.read git_private_key_file
-    expect(git_private_key_contents).to eq("git_key")
+    expect(git_private_key_contents).to eq("git_key\n")
   end
 
   it "configures ssl verification" do

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -16,6 +16,27 @@ describe "integration:ssh" do
   it "creates private key file" do
     stdin = {
         "source" => {
+            "ssh_private_key" => "key\n",
+            "debug" => true
+        },
+        "params" => {
+            "path" => "spec/fixtures",
+            "inventory" => "the_inventory"
+        }
+    }.to_json
+
+    stdout, stderr, status = Open3.capture3("#{out_file} .", :stdin_data => stdin)
+
+    expect(status.success?).to be true
+    expect(File).to exist(ssh_private_key_file)
+
+    ssh_private_key_contents = File.read ssh_private_key_file
+    expect(ssh_private_key_contents).to eq("key\n")
+  end
+
+  it "adds trailing newline to private key file" do
+    stdin = {
+        "source" => {
             "ssh_private_key" => "key",
             "debug" => true
         },
@@ -31,13 +52,13 @@ describe "integration:ssh" do
     expect(File).to exist(ssh_private_key_file)
 
     ssh_private_key_contents = File.read ssh_private_key_file
-    expect(ssh_private_key_contents).to eq("key")
+    expect(ssh_private_key_contents).to eq("key\n")
   end
 
   it "should create ssh config" do
     stdin = {
         "source" => {
-            "ssh_private_key" => "key"
+            "ssh_private_key" => "key\n"
         },
         "params" => {
             "path" => "spec/fixtures",


### PR DESCRIPTION
Concourse strips away trailing newlines in variables passed with the `--var` flag. This PR ensures that there is always a newline at the end of private key files.

This prevents issues like #14 and #9 