### PR TITLE
Fix .netrc syntax (password)

### DIFF
--- a/assets/lib/git_config.rb
+++ b/assets/lib/git_config.rb
@@ -14,7 +14,7 @@ class GitConfig
   def configure_https_credentials!(username, password)
     if !username.nil? and !password.nil?
       netrc_path = File.expand_path "~/.netrc"
-      File.write netrc_path, "default login #{username} #{password}\n"
+      File.write netrc_path, "default login #{username} password #{password}\n"
       return true
     end
     false

--- a/spec/integration/git_spec.rb
+++ b/spec/integration/git_spec.rb
@@ -76,7 +76,7 @@ describe "integration:git" do
     expect(File).to exist(netrc_file)
 
     netrc_contents = File.read netrc_file
-    expect(netrc_contents).to include("default login foo bar\n")
+    expect(netrc_contents).to include("default login foo password bar\n")
   end
 
   it "configures git globally" do


### PR DESCRIPTION
In case `git_https_username/password` is used, current version writes incorrect _.netrc_ file, which is then not recognized and not used. This patch adds the missing `password` token. Tested on my instance.