### PR TITLE
Fix pip "error: externally-managed-environment" during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN set -eux; \
       openssl-dev \
       musl-dev \
       cargo; \
-    pip3 install --upgrade pip cffi; \
-    pip3 install ansible boto pywinrm; \
+    pip3 install --upgrade pip cffi --break-system-packages; \
+    pip3 install ansible boto pywinrm --break-system-packages; \
     apk del build-dependencies; \
     rm -rf /var/cache/apk/*; \
 # Remove PIP and Cargo cache


### PR DESCRIPTION
Not sure if that's the way to handle it, but it fixes the following error when trying to build the docker image:

```
[...]
111.1 + pip3 install --upgrade pip cffi
111.8 error: externally-managed-environment
111.8 
111.8 × This environment is externally managed
111.8 ╰─> 
111.8     The system-wide python installation should be maintained using the system
111.8     package manager (apk) only.
111.8     
111.8     If the package in question is not packaged already (and hence installable via
111.8     "apk add py3-somepackage"), please consider installing it inside a virtual
111.8     environment, e.g.:
111.8     
111.8     python3 -m venv /path/to/venv
111.8     . /path/to/venv/bin/activate
111.8     pip install mypackage
111.8     
111.8     To exit the virtual environment, run:
111.8     
111.8     deactivate
111.8     
111.8     The virtual environment is not deleted, and can be re-entered by re-sourcing
111.8     the activate file.
111.8     
111.8     To automatically manage virtual environments, consider using pipx (from the
111.8     pipx package).
111.8 
111.8 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
111.8 hint: See PEP 668 for the detailed specification.
------
Dockerfile:3
--------------------
   2 |     
   3 | >>> RUN set -eux; \
   4 | >>>     apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates; \
   5 | >>>     apk --update add --virtual \
   6 | >>>       build-dependencies \
   7 | >>>       build-base \
   8 | >>>       python3-dev \
   9 | >>>       libffi-dev \
  10 | >>>       openssl-dev \
  11 | >>>       musl-dev \
  12 | >>>       cargo; \
  13 | >>>     pip3 install --upgrade pip cffi; \
  14 | >>>     pip3 install ansible boto pywinrm; \
  15 | >>>     apk del build-dependencies; \
  16 | >>>     rm -rf /var/cache/apk/*; \
  17 | >>> # Remove PIP and Cargo cache
  18 | >>> 	rm -rf /root/.cargo /root/.cache; \
  19 | >>> # Remove Python cache files
  20 | >>> 	find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf; \
  21 | >>> 	find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf; \
  22 | >>> # Add hosts for convenience
  23 | >>>     mkdir -p /etc/ansible; \
  24 | >>>     echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
  25 |     
  --------------------
ERROR: failed to solve: process "/bin/sh -c set -eux;     apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates;     apk --update add --virtual       build-dependencies       build-base       python3-dev       libffi-dev       openssl-dev       musl-dev       cargo;     pip3 install --upgrade pip cffi;     pip3 install ansible boto pywinrm;     apk del build-dependencies;     rm -rf /var/cache/apk/*; \trm -rf /root/.cargo /root/.cache; \tfind /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf; \tfind /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf;     mkdir -p /etc/ansible;     echo -e \"[local]\\nlocalhost ansible_connection=local\" > /etc/ansible/hosts" did not complete successfully: exit code: 1
  ```